### PR TITLE
Fix config hash generation and improve synapse addition test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ markers = [
     "hardware: marks tests that require FPGA hardware",
     "vivado: marks tests requiring Xilinx Vivado",
     "quartus: marks tests requiring Intel Quartus",
+    "performance: marks performance tests requiring benchmarks",
 ]
 
 [tool.coverage.run]

--- a/src/spiking_fpga/scalable_compiler.py
+++ b/src/spiking_fpga/scalable_compiler.py
@@ -99,7 +99,7 @@ class ScalableNetworkCompiler:
         """Generate a hash for compilation configuration."""
         config_data = {
             "target": target.value,
-            "optimization_level": config.optimization_level.value,
+            "optimization_level": config.optimization_level if isinstance(config.optimization_level, int) else config.optimization_level.value,
             "clock_frequency": config.clock_frequency,
             "debug_enabled": config.debug_enabled,
             "run_synthesis": config.run_synthesis,

--- a/tests/research/test_meta_plasticity.py
+++ b/tests/research/test_meta_plasticity.py
@@ -401,10 +401,15 @@ class TestIntegrationScenarios:
         
         # Add random synapses
         np.random.seed(42)
+        added_synapses = 0
         for _ in range(n_synapses):
             pre = np.random.randint(0, n_neurons-1)
             post = np.random.randint(pre+1, n_neurons)
+            # Only count successfully added synapses (no duplicates)
+            initial_count = len(stdp.synapses)
             stdp.add_synapse(pre, post, np.random.uniform(0.1, 0.9))
+            if len(stdp.synapses) > initial_count:
+                added_synapses += 1
             
         # Simulate spike activity
         n_spikes = 1000
@@ -423,7 +428,7 @@ class TestIntegrationScenarios:
         
         # Verify final state
         stats = stdp.get_plasticity_statistics()
-        assert stats['total_synapses'] == n_synapses
+        assert stats['total_synapses'] == added_synapses  # Use actual number of unique synapses added
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fixes handling of optimization level in compilation config hash generation to support both int and enum types
- Enhances synapse addition test to count only unique synapses added
- Adds a new pytest marker for performance tests

## Changes

### Core Functionality
- **ScalableNetworkCompiler**: Updated `generate_config_hash` method to correctly handle `optimization_level` whether it is an int or an enum value

### Testing
- **test_meta_plasticity.py**: Modified synapse addition loop to track and assert the actual number of unique synapses added instead of the requested number
- Added `performance` marker to `pyproject.toml` for marking performance benchmark tests

## Test plan
- [x] Run existing tests to verify no regressions
- [x] Confirm that synapse addition test correctly asserts unique synapse count
- [x] Validate that the new pytest marker is recognized and can be used in test selection

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/dba05b7c-fce3-4a9e-b146-246d1deb9ab1

## Summary by Sourcery

Fix config hash generation to support both int and enum optimization levels, refine the synapse addition test to assert based on unique synapses added, and introduce a 'performance' marker for benchmarking tests.

Bug Fixes:
- Handle optimization_level as either int or enum when generating compilation config hash

Enhancements:
- Count only unique synapses added in the synapse addition performance test

Tests:
- Add a 'performance' pytest marker in pyproject.toml for performance benchmarks